### PR TITLE
Feature: Add support for photo usage counters in Camera API client

### DIFF
--- a/spypointapi/cameras/camera.py
+++ b/spypointapi/cameras/camera.py
@@ -49,6 +49,10 @@ class Camera:
     transmit_freq: int | None = None
     transmit_time: TransmitTime | None = None
     trigger_speed: str | None = None
+    photo_count: int | None = None
+    hd_photo_count: int | None = None
+    photo_limit: int | None = None
+    hd_photo_limit: int | None = None
 
     @property
     def is_online(self) -> bool:
@@ -70,5 +74,7 @@ class Camera:
             f"operation_mode={self.operation_mode}, sensibility={self.sensibility}, "
             f"transmit_auto={self.transmit_auto}, transmit_format={self.transmit_format}, "
             f"transmit_freq={self.transmit_freq}, transmit_time={self.transmit_time}, "
-            f"trigger_speed={self.trigger_speed})"
+            f"trigger_speed={self.trigger_speed}), "
+            f"photo_count={self.photo_count}, hd_photo_count={self.hd_photo_count}, "
+            f"photo_limit={self.photo_limit}, hd_photo_limit={self.hd_photo_limit})"
         )

--- a/spypointapi/cameras/camera_api_response.py
+++ b/spypointapi/cameras/camera_api_response.py
@@ -15,6 +15,7 @@ class CameraApiResponse:
     def camera_from_json(cls, data: Dict[str, Any]) -> Camera:
         config = data.get('config', {})
         status = data.get('status', {})
+        subscriptions = data.get('subscriptions', [])
         return Camera(
             id=data['id'],
             name=config['name'],
@@ -44,6 +45,10 @@ class CameraApiResponse:
             transmit_freq=config.get('transmitFreq', None),
             transmit_time=CameraApiResponse.transmit_time_from_json(config.get('transmitTime', None)),
             trigger_speed=config.get('triggerSpeed', None),
+            photo_count=CameraApiResponse.subscription_counters_from_json(subscriptions).get('photoCount'),
+            hd_photo_count=CameraApiResponse.subscription_counters_from_json(subscriptions).get('hdPhotoCount'),
+            photo_limit=CameraApiResponse.subscription_counters_from_json(subscriptions).get('photoLimit'),
+            hd_photo_limit=CameraApiResponse.subscription_counters_from_json(subscriptions).get('hdPhotoLimit'),            
         )
 
     @classmethod
@@ -104,3 +109,13 @@ class CameraApiResponse:
             return None
         current_timezone = datetime.now().astimezone().tzinfo
         return datetime.fromisoformat(date_str.rstrip('Z')).replace(tzinfo=current_timezone)
+
+    @classmethod
+    def subscription_counters_from_json(cls, subs: list[dict[str, Any]] | None) -> dict[str, int | None]:
+        sub = subs[0] if subs else {}
+        return {
+            "photoCount": sub.get("photoCount"),
+            "hdPhotoCount": sub.get("hdPhotoCount"),
+            "photoLimit": sub.get("photoLimit"),
+            "hdPhotoLimit": sub.get("hdPhotoLimit"),
+        }


### PR DESCRIPTION
This pull request extends the API client to collect and expose the following subscription-related metrics from the API:
photoCount
hdPhotoCount
photoLimit
hdPhotoLimit

The feature was tested with the Basic plan. It would be great if someone could verify the behavior with Standard or Premium plans as well.

The primary motivation for this extension is to monitor plan usage, in addition to existing metrics like battery status and last connection time.